### PR TITLE
Eliminate race condition in thread_pool::resize().

### DIFF
--- a/cxxheaderonly/thread_pool.hpp
+++ b/cxxheaderonly/thread_pool.hpp
@@ -247,13 +247,15 @@ namespace thread_pool {
 		if (nrthreads < _threads.size())
 		{
 			// decreasing number of active threads
+			std::unique_lock<std::mutex> lock(_mutex);
 			for (std::size_t i = nrthreads; i < _threads.size(); ++i)
 				*(_threads_stop[i]) = true;
 			_condition.notify_all();
+			lock.unlock();
 			for (std::size_t i = nrthreads; i < _threads.size(); ++i)
 				_threads[i]->join();
 
-			std::unique_lock<std::mutex> lock(_mutex);
+			lock.lock();
 			_threads_stop.resize(nrthreads);
 			_threads.resize(nrthreads);
 		} 


### PR DESCRIPTION
The fplll project has imported thread_pool.hpp.  I maintain the Fedora Linux fplll package.  As I attempted to build the latest version of fplll, a test experienced a hang.  GDB showed that there were two threads.  One was in thread_pool::~thread_pool() -> thread_pool::stop() -> thread_pool::resize(0), where it was waiting to join the other thread.  The second thread was in thread_pool::_init_thread(), on the line that reads `this->_condition.wait(lock)`.  The problem appears to be a race condition due to the resize method not holding the lock while it sets the stop flag on the other threads and then notifies them.  That should be atomic.  This commit makes the resizing thread hold the lock while setting the flag and notifying, then drop the lock while it joins with the other threads, before acquiring the lock again to do the actual resize.