### PR TITLE
Replace using declaration with typedef

### DIFF
--- a/cxxheaderonly/progress_display.hpp
+++ b/cxxheaderonly/progress_display.hpp
@@ -14,7 +14,7 @@ namespace cxxheaderonly {
 
 	class progress_display {
 	public:
-		using std::uint64_t;
+		typedef std::uint64_t uint64;
 
 		explicit progress_display(uint64 expected_count, 
 										bool show_scale = true,


### PR DESCRIPTION
Fixes errors like:

```
[...]/progress_display.hpp:17:28: error: using-declaration for non-member at class scope
   17 |                 using std::uint64_t;
      |                            ^~~~~~~~
```

Additionally, name the typedef “`uint64`” instead of “`uint64_t`”, fixing errors like:

```
[...]/progress_display.hpp:31:30: error: 'uint64' has not been declared
   31 |                 void restart(uint64 expected_count)
      |                              ^~~~~~
```