### PR TITLE
parallel_algorithms.hpp: include <algorithm> for std::partition

### DIFF
--- a/cxxheaderonly/parallel_algorithms.hpp
+++ b/cxxheaderonly/parallel_algorithms.hpp
@@ -33,6 +33,8 @@
 #include "thread_pool.hpp"
 #include <cassert>
 
+#include <algorithm>
+
 /*************************** example usage ***************************************\
 grep "^//test.cpp" parallel_algoritms.hpp -A34 > test.cpp
 g++ -std=c++11 -o test test.cpp -pthread -lpthread


### PR DESCRIPTION
Fixes error in GCC 14:

```
error: ‘partition’ is not a member of ‘std’; did you mean ‘parallel_algorithms::partition’
```